### PR TITLE
ISBNUTIL-9: adding method to remove hyphens

### DIFF
--- a/src/main/java/org/folio/isbn/IsbnUtil.java
+++ b/src/main/java/org/folio/isbn/IsbnUtil.java
@@ -1,10 +1,14 @@
 package org.folio.isbn;
 
-import com.github.ladutsko.isbn.ISBNException;
-import com.github.ladutsko.isbn.ISBNFormat;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.validator.routines.ISBNValidator;
 import org.apache.commons.validator.routines.checkdigit.CheckDigitException;
 import org.apache.commons.validator.routines.checkdigit.ISBN10CheckDigit;
+
+import com.github.ladutsko.isbn.ISBNException;
+import com.github.ladutsko.isbn.ISBNFormat;
 
 /**
  * Class with utility methods for working with ISBN number
@@ -101,5 +105,12 @@ public final class IsbnUtil {
     } catch (ISBNException e) {
       throw new IllegalArgumentException(e.getMessage(), e);
     }
+  }
+
+  public static String removeHyphens(String isbn) {
+    if (!(isValid10DigitNumber(isbn) || isValid13DigitNumber(isbn))) {
+      throw new IllegalArgumentException("ISBN value is invalid: " + isbn);
+    }
+    return Stream.of(isbn.split("-")).collect(Collectors.joining());
   }
 }

--- a/src/test/java/org/folio/IsbnUtilTest.java
+++ b/src/test/java/org/folio/IsbnUtilTest.java
@@ -170,4 +170,21 @@ public class IsbnUtilTest extends TestCase {
       Assert.assertNotNull(e);
     }
   }
+
+  public void testRemoveHyphens() {
+    assertEquals("9780321130020", IsbnUtil.removeHyphens("978-0-321-13002-0"));
+    assertEquals("0321130022", IsbnUtil.removeHyphens("0-321-13002-2"));
+    assertEquals("9791090636071", IsbnUtil.removeHyphens("979-10-90636-07-1"));
+    assertEquals("9780122746024", IsbnUtil.removeHyphens("978-0-12-274602-4"));
+    assertEquals("9999999999", IsbnUtil.removeHyphens("9999999999"));
+  }
+
+  public void testRemoveHyphensToIsbnThrowExceptionWhenSpecifiedInvalidIsbn() {
+    try {
+      IsbnUtil.removeHyphens("BR18694353");
+      fail("Expected IllegalArgumentException when specified invalid ISBN");
+    } catch (IllegalArgumentException e) {
+      Assert.assertNotNull(e);
+    }
+  }
 }


### PR DESCRIPTION
## Purpose
Add the ability to explicitly remove hyphens from a valid ISBN
See https://issues.folio.org/browse/ISBNUTIL-9