### PR TITLE
ISBNUTIL-15: commons-validator 1.7 (CVE-2019-10086)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>1.6</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Upgrade commons-validator from 1.6 to 1.7. This indirectly upgrades commons-beanutils from 1.9.2 to 1.9.4 fixing Deserialization of Untrusted Data: https://nvd.nist.gov/vuln/detail/CVE-2019-10086