### PR TITLE
ISBNUTIL-27: Update to folio-isbn-util Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java17'
+  buildNode = 'jenkins-agent-java21'
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.8.0 2025-XX-XX
+* [ISBNUTIL-27](https://folio-org.atlassian.net/browse/ISBNUTIL-27) Update to folio-isbn-util Java 21
+
 ## 1.7.0 2024-11-21
 * [ISBNUTIL-23](https://folio-org.atlassian.net/browse/ISBNUTIL-23) Upgrade dependencies for Ramsons; fix jackson-core DoS
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <release>17</release>
+          <release>21</release>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Purpose
The main goal is to update library to Java 21.

## Learning
JIRA: https://folio-org.atlassian.net/browse/ISBNUTIL-27
